### PR TITLE
Build fatjar using separate class as an entrypoint.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,31 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.4.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <dependencyReducedPomLocation>
+                                ${java.io.tmpdir}/dependency-reduced-pom.xml
+                            </dependencyReducedPomLocation>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.example.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.openjfx</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>0.0.8</version>

--- a/src/main/java/com/example/Main.java
+++ b/src/main/java/com/example/Main.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Main {
+    public static void main(String[] args) {
+        com.example.ui.Main.main(args);
+    }
+}


### PR DESCRIPTION
Dodana klasa startowa `com.example.Main.java` która **nie** dziedziczy po `javafx.application.Application`, dzięki czemu można użyć jej z tzw. fat jar (plik jar ze wszystkimi zależnościami - javafx, sterownik sqlite).

W `pom.xml` dodany plugin do budowania fat jar.

Po zintegrowaniu zmian i zbudowaniu aplikacji (maven / package) wykonanie poniższego polecenia w katalogu `target` pozwoli na uruchomienie aplikacji poza IDE.

```bash
java -jar FoodRater-1.0-SNAPSHOT.jar
```